### PR TITLE
Added types for riteway/match and riteway/render-component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,11 +30,3 @@ declare module 'riteway' {
     readonly objectMode: boolean
   }
 }
-
-declare module "riteway/render-component" {
-  export default function render(el: JSX.Element): cheerio.Root;
-}
-
-declare module "riteway/match" {
-  export default function match(text: string): (pattern: string | RegExp) => string;
-}

--- a/match.d.ts
+++ b/match.d.ts
@@ -1,0 +1,5 @@
+declare module 'riteway/match' {
+  export default function match(
+    text: string
+  ): (pattern: string | RegExp) => string;
+}

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "./match": {
       "import": "./source/match.js",
       "require": "./source/match.js",
-      "types": "./index.d.ts"
+      "types": "./match.d.ts"
     },
     "./render-component": {
       "import": "./source/render-component.js",
       "require": "./source/render-component.js",
-      "types": "./index.d.ts"
+      "types": "./render-component.d.ts"
     }
   },
   "bin": {

--- a/render-component.d.ts
+++ b/render-component.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="cheerio" />
+/// <reference types="react" />
+
+declare module 'riteway/render-component' {
+  export default function render(el: JSX.Element): cheerio.Root;
+}


### PR DESCRIPTION
I discovered that render-component and match typing only worked when you *also* imported from "riteway" in addition to "riteway/match".

This minor update allows both match and render-component to be imported standalone without depending on the main "riteway" import.