### PR TITLE
Change `toEqual` to `toStrictEqual`

### DIFF
--- a/esm/vitest.js
+++ b/esm/vitest.js
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
 
 export const assert = ({ given, should, actual, expected }) => {
-  expect(actual, `Given ${given}: should ${should}`).toEqual(expected);
+  expect(actual, `Given ${given}: should ${should}`).toStrictEqual(expected);
 };

--- a/source/vitest.js
+++ b/source/vitest.js
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
 
 export const assert = ({ given, should, actual, expected }) => {
-  expect(actual, `Given ${given}: should ${should}`).toEqual(expected);
+  expect(actual, `Given ${given}: should ${should}`).toStrictEqual(expected);
 };


### PR DESCRIPTION
We are using `toStrictEqual` instead of `toEqual`. 

`toStrictEqual` is used when you want to do a deep comparison like toEqual, but also check the types. It checks that objects have the same types as well as structure.